### PR TITLE
Dealid and Rewarded inventory's PR Fixes

### DIFF
--- a/adapters/improvedigital/improvedigital.go
+++ b/adapters/improvedigital/improvedigital.go
@@ -30,7 +30,7 @@ type ImprovedigitalAdapter struct {
 // BidExt This struct usage for parse line_item_id and buying_type from bid.ext
 type BidExt struct {
 	Improvedigital struct {
-		LineItemId int    `json:"line_item_id"`
+		LineItemID int    `json:"line_item_id"`
 		BuyingType string `json:"buying_type"`
 	}
 }
@@ -55,12 +55,12 @@ func (a *ImprovedigitalAdapter) MakeRequests(request *openrtb2.BidRequest, reqIn
 
 func (a *ImprovedigitalAdapter) makeRequest(request openrtb2.BidRequest, imp openrtb2.Imp) (*adapters.RequestData, error) {
 	// Handle Rewarded Inventory
-	extImp, err := getImpExtWithRewardedInventory(imp)
+	impExt, err := getImpExtWithRewardedInventory(imp)
 	if err != nil {
 		return nil, err
 	}
-	if extImp != nil {
-		imp.Ext = extImp
+	if impExt != nil {
+		imp.Ext = impExt
 	}
 
 	request.Imp = []openrtb2.Imp{imp}
@@ -149,8 +149,8 @@ func (a *ImprovedigitalAdapter) MakeBids(internalRequest *openrtb2.BidRequest, e
 			}
 
 			bidExtImprovedigital := bidExt.Improvedigital
-			if bidExtImprovedigital.LineItemId != 0 && bidExtImprovedigital.BuyingType != "" && bidExtImprovedigital.BuyingType != buyingTypeRTB {
-				bid.DealID = strconv.Itoa(bidExtImprovedigital.LineItemId)
+			if bidExtImprovedigital.LineItemID != 0 && bidExtImprovedigital.BuyingType != "" && bidExtImprovedigital.BuyingType != buyingTypeRTB {
+				bid.DealID = strconv.Itoa(bidExtImprovedigital.LineItemID)
 			}
 		}
 

--- a/adapters/improvedigital/improvedigital.go
+++ b/adapters/improvedigital/improvedigital.go
@@ -27,7 +27,7 @@ type ImprovedigitalAdapter struct {
 	endpoint string
 }
 
-// BidExt This struct usage for parse line_item_id and buying_type from bid.ext
+// BidExt represents Improved Digital bid extension with line item ID and buying type values
 type BidExt struct {
 	Improvedigital struct {
 		LineItemID int    `json:"line_item_id"`

--- a/adapters/improvedigital/improvedigitaltest/supplemental/rewarded-inventory.json
+++ b/adapters/improvedigital/improvedigitaltest/supplemental/rewarded-inventory.json
@@ -6,7 +6,7 @@
     },
     "imp": [
       {
-        "id": "rewarded-inventory-imp-id",
+        "id": "rewarded-inventory-imp-id-true",
         "banner": {
           "format": [
             {
@@ -25,7 +25,7 @@
         }
       },
       {
-        "id": "rewarded-inventory-imp-id",
+        "id": "rewarded-inventory-imp-id-false",
         "banner": {
           "format": [
             {
@@ -42,6 +42,23 @@
             "is_rewarded_inventory": 0
           }
         }
+      },
+      {
+        "id": "rewarded-inventory-imp-id-not-defined",
+        "banner": {
+          "format": [
+            {
+              "w": 300,
+              "h": 250
+            }
+          ]
+        },
+        "ext": {
+          "bidder": {
+            "placementId": 13245
+          },
+          "prebid": {}
+        }
       }
     ]
   },
@@ -56,7 +73,7 @@
           },
           "imp": [
             {
-              "id": "rewarded-inventory-imp-id",
+              "id": "rewarded-inventory-imp-id-true",
               "banner": {
                 "format": [
                   {
@@ -93,7 +110,7 @@
           },
           "imp": [
             {
-              "id": "rewarded-inventory-imp-id",
+              "id": "rewarded-inventory-imp-id-false",
               "banner": {
                 "format": [
                   {
@@ -118,9 +135,43 @@
         "status": 200,
         "body": {}
       }
+    },
+    {
+      "expectedRequest": {
+        "uri": "http://localhost/pbs",
+        "body": {
+          "id": "rewarded-inventory-request-id",
+          "site": {
+            "page": "https://good.site/url"
+          },
+          "imp": [
+            {
+              "id": "rewarded-inventory-imp-id-not-defined",
+              "banner": {
+                "format": [
+                  {
+                    "w": 300,
+                    "h": 250
+                  }
+                ]
+              },
+              "ext": {
+                "bidder": {
+                  "placementId": 13245
+                },
+                "prebid": {}
+              }
+            }
+          ]
+        }
+      },
+      "mockResponse": {
+        "status": 200,
+        "body": {}
+      }
     }
   ],
   "expectedBidResponses": [
-    {},{}
+    {},{},{}
   ]
 }


### PR DESCRIPTION
This PR contain two variable name changes and include a test case when `is_rewarded_inventory` is not defined